### PR TITLE
Fix Teams webhook user parsing

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -27,9 +27,15 @@ def post_webhook(name: str, url: str, message: str, event_data: dict) -> bool:
         # Microsoft Teams Webhooks
         elif "webhook.office.com" in url:
             action = event_data.get("action", "undefined")
+            user_info = event_data.get("user", {})
+            if isinstance(user_info, str):
+                try:
+                    user_info = json.loads(user_info)
+                except Exception:
+                    user_info = {}
             facts = [
                 {"name": name, "value": value}
-                for name, value in json.loads(event_data.get("user", {})).items()
+                for name, value in user_info.items()
             ]
             payload = {
                 "@type": "MessageCard",


### PR DESCRIPTION
## Summary
- fix user info parsing for Microsoft Teams webhooks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_684156597d888327a8ba55727f8aa2f5