### PR TITLE
feat(frontend): Dynamically resize message input for knowledge sources

### DIFF
--- a/acp-3835-selectable-knowledge-source/README.md
+++ b/acp-3835-selectable-knowledge-source/README.md
@@ -42,7 +42,7 @@ An example value for the `MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING` environment vari
 
 The frontend implementation is handled by three main Svelte components:
 
--   **`src/lib/components/chat/MessageInput.svelte`**: This component is responsible for rendering the knowledge source selection buttons. It contains a reactive variable `knowledgeSources` that is populated based on the `model_id_to_knowledge_source_mapping` from the config and the currently selected model. When a user clicks a button, the `selectedKnowledgeSources` array is updated.
+-   **`src/lib/components/chat/MessageInput.svelte`**: This component is responsible for rendering the knowledge source selection buttons. It contains a reactive variable `knowledgeSources` that is populated based on the `model_id_to_knowledge_source_mapping` from the config and the currently selected model. When a user clicks a button, the `selectedKnowledgeSources` array is updated. The component also ensures that the input area dynamically expands to fit all available knowledge source buttons, wrapping them into multiple rows if necessary.
 
 -   **`src/lib/components/chat/Chat.svelte`**: This component manages the chat session. In the `submitPrompt` function, it checks if the `selectedKnowledgeSources` array is populated. If it is, and the chat is new, it appends a message to the user's prompt.
 

--- a/acp-3835-selectable-knowledge-source/README.md
+++ b/acp-3835-selectable-knowledge-source/README.md
@@ -1,0 +1,69 @@
+# Selectable Knowledge Source Feature
+
+This document outlines the implementation of the selectable knowledge source feature, which allows users to specify knowledge sources for the model to use during a chat session.
+
+## Feature Overview
+
+The selectable knowledge source feature enables users to guide the model's responses by selecting from a predefined list of knowledge sources. When a user starts a new chat and selects one or more knowledge sources, the initial prompt is modified to instruct the model to prioritize information from those sources.
+
+### How It Works
+
+1.  **Configuration**: A mapping between model IDs and available knowledge sources is defined in the backend configuration.
+2.  **User Interface**: When a user selects a model, the UI displays buttons for each knowledge source associated with that model.
+3.  **Selection**: The user can click on the knowledge source buttons to select or deselect them.
+4.  **Prompt Modification**: When a new chat is initiated with knowledge sources selected, a message is appended to the user's prompt, instructing the model to use the selected sources.
+
+## Implementation Details
+
+### Backend
+
+The feature is configured in `backend/open_webui/config.py` using the `MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING` setting. This persistent configuration stores a JSON object that maps model IDs to an array of knowledge source names.
+
+**Example Configuration:**
+
+```python
+MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING = PersistentConfig(
+    "MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING",
+    "ui.model_id_to_knowledge_source_mapping",
+    os.environ.get("MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING", "{}"),
+)
+```
+
+An example value for the `MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING` environment variable would be:
+
+```json
+{
+  "gemma:7b": ["Internal Docs", "Product Specs"],
+  "llama3:8b": ["General Knowledge", "User Guides"]
+}
+```
+
+### Frontend
+
+The frontend implementation is handled by three main Svelte components:
+
+-   **`src/lib/components/chat/MessageInput.svelte`**: This component is responsible for rendering the knowledge source selection buttons. It contains a reactive variable `knowledgeSources` that is populated based on the `model_id_to_knowledge_source_mapping` from the config and the currently selected model. When a user clicks a button, the `selectedKnowledgeSources` array is updated.
+
+-   **`src/lib/components/chat/Chat.svelte`**: This component manages the chat session. In the `submitPrompt` function, it checks if the `selectedKnowledgeSources` array is populated. If it is, and the chat is new, it appends a message to the user's prompt.
+
+    ```javascript
+    if (
+      (messages.length === 0 || history.currentId === null) &&
+      selectedKnowledgeSources.length > 0
+    ) {
+      userPrompt = `${userPrompt}\n\nI have selected these knowledge source(s): [${selectedKnowledgeSources.join(
+        ', '
+      )}], please find information relevant to my query in these sources.`;
+    }
+    ```
+
+-   **`src/lib/components/chat/Placeholder.svelte`**: This component also receives the `selectedKnowledgeSources` prop to ensure that the selection is maintained even when the chat view is in its placeholder state.
+
+## Usage
+
+To use this feature:
+
+1.  Set the `MODEL_ID_TO_KNOWLEDGE_SOURCE_MAPPING` environment variable or update the configuration in the database with the desired model-to-source mappings.
+2.  In the UI, select a model that has associated knowledge sources.
+3.  Click the buttons for the desired knowledge sources to select them.
+4.  Start a new chat. The model will be instructed to use the selected sources.

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1082,7 +1082,7 @@ selectedKnowledgeSources = [];
 								</div>
 
 								<div class=" flex justify-between mt-1 mb-2.5 mx-0.5 max-w-full" dir="ltr">
-									<div class="ml-1 self-end flex items-center flex-1 max-w-[80%] gap-0.5">
+									<div class="ml-1 self-end flex items-center flex-1 gap-0.5">
 										<InputMenu
 											bind:selectedToolIds
 											{screenCaptureHandler}
@@ -1150,7 +1150,7 @@ selectedKnowledgeSources = [];
 											</button>
 										</InputMenu>
 
-										<div class="flex gap-1 items-center overflow-x-auto scrollbar-none flex-1">
+										<div class="flex gap-1 items-center flex-wrap flex-1">
 											{#if toolServers.length + selectedToolIds.length > 0}
 												<Tooltip
 													content={$i18n.t('{{COUNT}} Available Tools', {


### PR DESCRIPTION
feat(frontend): Dynamically resize message input for knowledge sources

Resolves an issue where knowledge source buttons would overflow their container and become inaccessible when too many were present.

This commit modifies `src/lib/components/chat/MessageInput.svelte` to allow the flex container for knowledge source buttons to wrap its content. The width constraint has been removed, enabling the message input area to dynamically expand in height to accommodate all available buttons.

This ensures that all knowledge source buttons are visible and clickable, regardless of their quantity. The feature's README has also been updated to document this new behavior.
