### PR TITLE
fix(ACP-5048): prevent raw streaming XML from rendering in chat UI

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -144,6 +144,8 @@
 								})}
 							/>
 						{/if}
+					{:else if attributes?.type === 'streaming'}
+						{$i18n.t('Agent Execution Log')}
 					{:else}
 						{title}
 					{/if}

--- a/src/lib/utils/__tests__/streamingDetails.test.ts
+++ b/src/lib/utils/__tests__/streamingDetails.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { stripIncompleteDetails, processResponseContent } from '$lib/utils';
+
+/**
+ * ACP-5048: Simulate the exact streaming scenario seen on dev.
+ * The backend yields chunks like:
+ *   t=0: '<details type="streaming">\n<summary>...'
+ *   t=1: '...more events...'
+ *   t=N: '\n</details>\n\n---\n\nFinal answer'
+ *
+ * During streaming (before </details> arrives), the accumulated content
+ * has an unclosed <details> tag which the marked extension cannot parse,
+ * causing it to render as raw XML text.
+ */
+describe('Streaming details scenario (ACP-5048)', () => {
+	const streamingOpen =
+		'<details type="streaming">\n' +
+		'<summary>🔄 Real-time Agent Execution</summary>\n' +
+		'\n🚀 Starting real-time workflow execution...\n';
+
+	const streamingEvents =
+		'\n🚀 [Orchestrator] Starting query analysis...\n' +
+		'\n💭 [Orchestrator] Thinking: Calling tool\n' +
+		'\n⚡ [Orchestrator] Action: execute_plan\n';
+
+	const streamingClose = '\n</details>\n';
+
+	const separator = '\n---\n\n';
+
+	const finalAnswer = '## Results\n\nHere are the Zen 5 specs...';
+
+	it('strips incomplete details during streaming (open tag only)', () => {
+		// Simulates early streaming: only the opening tag arrived
+		const partial = streamingOpen;
+		const result = stripIncompleteDetails(partial);
+		expect(result).not.toContain('<details');
+		expect(result).toBe('');
+	});
+
+	it('strips incomplete details during streaming (open + events)', () => {
+		// Simulates mid-streaming: events arriving but no closing tag yet
+		const partial = streamingOpen + streamingEvents;
+		const result = stripIncompleteDetails(partial);
+		expect(result).not.toContain('<details');
+	});
+
+	it('keeps complete details block intact', () => {
+		// Simulates after streaming completes: full block with closing tag
+		const complete = streamingOpen + streamingEvents + streamingClose;
+		const result = stripIncompleteDetails(complete);
+		expect(result).toContain('<details');
+		expect(result).toContain('</details>');
+	});
+
+	it('keeps complete block + final answer intact', () => {
+		const full = streamingOpen + streamingEvents + streamingClose + separator + finalAnswer;
+		const result = stripIncompleteDetails(full);
+		expect(result).toContain('<details');
+		expect(result).toContain('</details>');
+		expect(result).toContain('## Results');
+	});
+
+	it('processResponseContent strips incomplete tags during streaming', () => {
+		const partial = streamingOpen + streamingEvents;
+		const result = processResponseContent(partial);
+		expect(result).not.toContain('<details');
+	});
+
+	it('processResponseContent preserves complete content', () => {
+		const full = streamingOpen + streamingEvents + streamingClose + separator + finalAnswer;
+		const result = processResponseContent(full);
+		expect(result).toContain('<details');
+		expect(result).toContain('## Results');
+	});
+
+	it('handles the exact output seen on dev (raw XML bug)', () => {
+		// This is the exact pattern that was rendered as raw text on dev
+		const devOutput =
+			'<details type="streaming">\n' +
+			'<summary>🔄 Real-time Agent Execution</summary>\n' +
+			'\n🚀 Starting real-time workflow execution...\n' +
+			'\n🚀 [Orchestrator] Starting query analysis...\n' +
+			'\n💭 [Orchestrator] Thinking: Calling tool\n' +
+			'\n⚡ [Orchestrator] Action: execute_plan\n' +
+			'📝 Input: {}\n' +
+			'\n🚀 [JiraAnalysisAgent] Starting...\n' +
+			'\n🚀 [PowerBIAgent] Starting...\n';
+		// No closing </details> — this is what the user sees during streaming
+
+		const result = processResponseContent(devOutput);
+		// Should NOT contain raw <details> tag
+		expect(result).not.toContain('<details');
+		expect(result).not.toContain('<summary>');
+	});
+});

--- a/src/lib/utils/__tests__/stripIncompleteDetails.test.ts
+++ b/src/lib/utils/__tests__/stripIncompleteDetails.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { stripIncompleteDetails } from '$lib/utils';
+
+describe('stripIncompleteDetails (ACP-5048)', () => {
+	it('leaves complete details blocks intact', () => {
+		const content =
+			'<details type="streaming">\n<summary>S</summary>\nevents\n</details>\n\n---\n\nFinal answer';
+		expect(stripIncompleteDetails(content)).toBe(content);
+	});
+
+	it('removes incomplete opening tag at end', () => {
+		const content = 'Some text\n<details type="strea';
+		const result = stripIncompleteDetails(content);
+		expect(result).toBe('Some text\n');
+	});
+
+	it('removes incomplete details block without closing tag', () => {
+		const content =
+			'<details type="streaming">\n<summary>🔄 Real-time Agent Execution</summary>\n\n🚀 Starting...';
+		const result = stripIncompleteDetails(content);
+		expect(result).toBe('');
+	});
+
+	it('removes only the unclosed block, keeps closed ones', () => {
+		const content =
+			'<details type="reasoning">\n<summary>R</summary>\nthoughts\n</details>\n' +
+			'<details type="streaming">\n<summary>S</summary>\nevents...';
+		const result = stripIncompleteDetails(content);
+		expect(result).toContain('</details>');
+		expect(result).toContain('type="reasoning"');
+		expect(result).not.toContain('type="streaming"');
+	});
+
+	it('handles content with no details tags', () => {
+		const content = 'Just some regular markdown content';
+		expect(stripIncompleteDetails(content)).toBe(content);
+	});
+
+	it('handles empty string', () => {
+		expect(stripIncompleteDetails('')).toBe('');
+	});
+
+	it('handles multiple complete blocks', () => {
+		const content =
+			'<details type="a">\n<summary>A</summary>\na\n</details>\n' +
+			'<details type="b">\n<summary>B</summary>\nb\n</details>\n' +
+			'Final text';
+		expect(stripIncompleteDetails(content)).toBe(content);
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -121,7 +121,31 @@ export const sanitizeResponseContent = (content: string) => {
 };
 
 export const processResponseContent = (content: string) => {
+	// ACP-5048: Strip incomplete <details> tags that appear during streaming.
+	// During streaming, content accumulates character-by-character, so we may
+	// have an opening <details> without a matching </details>. The marked
+	// extension cannot parse incomplete tags, causing them to render as raw text.
+	content = stripIncompleteDetails(content);
 	return content.trim();
+};
+
+/**
+ * Strip incomplete (unclosed) <details> tags from the end of streaming content.
+ * Only removes the trailing unclosed block — fully closed blocks are left intact.
+ */
+export const stripIncompleteDetails = (content: string): string => {
+	// Count opening and closing <details> tags
+	const openTags = content.match(/<details[\s>]/gi) || [];
+	const closeTags = content.match(/<\/details>/gi) || [];
+
+	if (openTags.length > closeTags.length) {
+		// There's at least one unclosed <details> — find and remove the last unclosed one
+		const lastOpenIdx = content.lastIndexOf('<details');
+		if (lastOpenIdx !== -1) {
+			content = content.slice(0, lastOpenIdx);
+		}
+	}
+	return content;
 };
 
 export function unescapeHtml(html: string) {
@@ -807,7 +831,7 @@ export const removeAllDetails = (content) => {
 };
 
 export const processDetails = (content) => {
-	content = removeDetails(content, ['reasoning', 'code_interpreter']);
+	content = removeDetails(content, ['reasoning', 'code_interpreter', 'streaming']);
 
 	// This regex matches <details> tags with type="tool_calls" and captures their attributes to convert them to <tool_calls> tags
 	const detailsRegex = /<details\s+type="tool_calls"([^>]*)>([\s\S]*?)<\/details>/gis;


### PR DESCRIPTION
### Description
                                                                                                                                    fix(ACP-5048): prevent raw streaming XML from rendering in chat UI
                                                                                                                                    
  During streaming, incomplete `<details type="streaming">` tags cannot be parsed by the marked extension tokenizer, causing them to render as raw XML text to the user.

  ### Fixed

  - Add `stripIncompleteDetails()` to remove unclosed `<details>` tags during streaming, called from `processResponseContent()`
  - Add `'streaming'` to `processDetails()` removal list so completed streaming blocks are properly hidden
  - Add `type="streaming"` display label ("Agent Execution Log") in Collapsible component

  ### Added

  - 14 unit tests covering streaming scenarios (including exact dev reproduction case)

  ### Additional Information

  - Related backend fix already deployed to dev (pipeline repo: `orchestrator_agent_workflow.py`)
  - After merge, need Roger to build new version and update dev Dockerfile