### PR TITLE
fix(ntid): propagate NTID into __user__ for Function pipe() calls

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -236,6 +236,7 @@ async def generate_function_chat_completion(
             "email": user.email,
             "name": user.name,
             "role": user.role,
+            "ntid": user.ntid or "",
         },
         "__metadata__": metadata,
         "__request__": request,

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -321,6 +321,7 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
             "email": user.email,
             "name": user.name,
             "role": user.role,
+            "ntid": user.ntid or "",
         },
         "__metadata__": metadata,
         "__request__": request,
@@ -427,6 +428,7 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
                     "email": user.email,
                     "name": user.name,
                     "role": user.role,
+                    "ntid": user.ntid or "",
                 }
 
                 try:


### PR DESCRIPTION
## Root Cause

PR #44 added `user.ntid` to `payload["user"]` in `openai.py` (covers pipeline-server mode), but the **Function framework** injects `__user__` from a **separate code path** that was not updated.

When `azure_ai_pipeline.py` (pipe-type Function) runs, `__user__` comes from `functions.py:generate_function_chat_completion`, which only had `id`, `email`, `name`, `role` — no `ntid`. This caused:

```
[NTID] user header value: <empty, header omitted>
```

on **every** Function call even after a successful Graph fetch on login.

## Three missed locations

| File | Line | Context |
|---|---|---|
| `backend/open_webui/functions.py` | 234 | `generate_function_chat_completion` — primary path for all pipe-type Functions |
| `backend/open_webui/utils/chat.py` | 319 | `extra_params` for outlet/filter functions |
| `backend/open_webui/utils/chat.py` | 425 | `chat_action` |

## Fix

Added `"ntid": user.ntid or ""` to all three `__user__` dicts, matching the existing pattern from `openai.py:665`.

## Test

After deploying: send any chat using a pipe-type Function (e.g. AMD Azure AI for GPT: gpt-4o) and confirm the log shows:
`[NTID] user header value: <set>` instead of `<empty, header omitted>`.

Fixes: ACP-5078

🤖 Generated with [Claude Code](https://claude.com/claude-code)